### PR TITLE
Ensure kernel parameters are absent from both GRUB_CMDLINE_LINUX and GRUB_CMDLINE_LINUX_DEFAULT

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
     which("grub2-mkconfig") or which("grub-mkconfig") or '/usr/sbin/grub-mkconfig'
   end
 
-  defaultfor :osfamily => 'Redhat', :operatingsystemmajrelease => [ '7' ]
+  defaultfor :osfamily => 'RedHat', :operatingsystemmajrelease => [ '7' ]
   defaultfor :operatingsystem => 'Debian', :operatingsystemmajrelease => [ '8' ]
   defaultfor :operatingsystem => 'Ubuntu', :operatingsystemmajrelease => [ '14.04' ]
 

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -77,6 +77,13 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
     self.value=(resource[:value])
   end
 
+  def destroy
+    augopen! do |aug|
+      aug.rm("$target/GRUB_CMDLINE_LINUX_DEFAULT/value[.=~regexp('^#{resource[:name]}(=.*)?$')]")
+      aug.rm("$target/GRUB_CMDLINE_LINUX/value[.=~regexp('^#{resource[:name]}(=.*)?$')]")
+    end
+  end
+
   def value
     augopen do |aug|
       aug.match('$resource').map {|vp|

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -239,6 +239,32 @@ describe provider_class do
       ')
     end
 
+    it "should delete entries from GRUB_CMDLINE_LINUX_DEFAULT with bootmode all" do
+      provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
+      provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
+
+      apply!(Puppet::Type.type(:kernel_parameter).new(
+        :name     => "rhgb",
+        :ensure   => "absent",
+        :bootmode => :all,
+        :target   => target,
+        :provider => "grub2"
+      ))
+
+      augparse_filter(target, LENS, FILTER, '
+        { "GRUB_CMDLINE_LINUX"
+          { "quote" = "\"" }
+          { "value" = "quiet" }
+          { "value" = "elevator=noop" }
+          { "value" = "divider=10" }
+        }
+        { "GRUB_CMDLINE_LINUX_DEFAULT"
+          { "quote" = "\"" }
+          { "value" = "nohz=on" }
+        }
+      ')
+    end
+
     describe "when modifying values" do
       before :each do
         provider_class.any_instance.stubs(:create).never


### PR DESCRIPTION
See https://github.com/hercules-team/augeasproviders_grub/issues/52#issuecomment-734251681

This patch expresses basically what I think should happen, but I don't know why it's not removing the parameter from `GRUB_CMDLINE_LINUX_DEFAULT`. Could use some help with this.