### PR TITLE
Drop stderr from mkconfig output when updating grub 

### DIFF
--- a/lib/puppet/provider/grub_config/grub2.rb
+++ b/lib/puppet/provider/grub_config/grub2.rb
@@ -20,7 +20,12 @@ Puppet::Type.type(:grub_config).provide(:grub2, parent: Puppet::Type.type(:augea
   end
 
   confine feature: :augeas
-  commands mkconfig: mkconfig_path
+
+  confine exists: mkconfig_path, for_binary: true
+
+  def mkconfig
+    execute(mkconfig_path, { failonfail: true, combine: false })
+  end
 
   defaultfor osfamily: :RedHat
 

--- a/lib/puppet/provider/grub_config/grub2.rb
+++ b/lib/puppet/provider/grub_config/grub2.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:grub_config).provide(:grub2, parent: Puppet::Type.type(:augea
   confine exists: mkconfig_path, for_binary: true
 
   def mkconfig
-    execute(mkconfig_path, { failonfail: true, combine: false })
+    execute(self.class.mkconfig_path, { failonfail: true, combine: false })
   end
 
   defaultfor osfamily: :RedHat

--- a/lib/puppet/provider/grub_menuentry/grub2.rb
+++ b/lib/puppet/provider/grub_menuentry/grub2.rb
@@ -253,7 +253,7 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2, parent: Puppet::Type.type(:au
   confine exists: mkconfig_path, for_binary: true
 
   def mkconfig
-    execute(mkconfig_path, { failonfail: true, combine: false })
+    execute(self.class.mkconfig_path, { failonfail: true, combine: false })
   end
 
   commands grubby: 'grubby'

--- a/lib/puppet/provider/grub_menuentry/grub2.rb
+++ b/lib/puppet/provider/grub_menuentry/grub2.rb
@@ -250,7 +250,12 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2, parent: Puppet::Type.type(:au
 
   #### End Class Methods
 
-  commands mkconfig: mkconfig_path
+  confine exists: mkconfig_path, for_binary: true
+
+  def mkconfig
+    execute(mkconfig_path, { failonfail: true, combine: false })
+  end
+
   commands grubby: 'grubby'
   commands grub_set_default: 'grub2-set-default'
 

--- a/lib/puppet/provider/grub_user/grub2.rb
+++ b/lib/puppet/provider/grub_user/grub2.rb
@@ -14,7 +14,11 @@ Puppet::Type.type(:grub_user).provide(:grub2, parent: Puppet::Type.type(:augeasp
     which('grub2-mkconfig') or which('grub-mkconfig') or '/usr/sbin/grub-mkconfig'
   end
 
-  commands mkconfig: mkconfig_path
+  confine exists: mkconfig_path, for_binary: true
+
+  def mkconfig
+    execute(mkconfig_path, { failonfail: true, combine: false })
+  end
 
   confine exists: '/etc/grub.d'
 

--- a/lib/puppet/provider/grub_user/grub2.rb
+++ b/lib/puppet/provider/grub_user/grub2.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:grub_user).provide(:grub2, parent: Puppet::Type.type(:augeasp
   confine exists: mkconfig_path, for_binary: true
 
   def mkconfig
-    execute(mkconfig_path, { failonfail: true, combine: false })
+    execute(self.class.mkconfig_path, { failonfail: true, combine: false })
   end
 
   confine exists: '/etc/grub.d'

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
   confine exists: mkconfig_path, for_binary: true
 
   def mkconfig
-    execute(mkconfig_path, { failonfail: true, combine: false })
+    execute(self.class.mkconfig_path, { failonfail: true, combine: false })
   end
 
   # when both grub* providers match, prefer GRUB 2

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -28,7 +28,12 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
 
   confine feature: :augeas
   defaultfor augeasprovider_grub_version: 2
-  commands mkconfig: mkconfig_path
+
+  confine exists: mkconfig_path, for_binary: true
+
+  def mkconfig
+    execute(mkconfig_path, { failonfail: true, combine: false })
+  end
 
   # when both grub* providers match, prefer GRUB 2
   def self.specificity


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
These updates prevent writing stderr out to grub.cfg when rebuilding grub config.

#### This Pull Request (PR) fixes the following issues
Fixes #74
