### PR TITLE
Update BLS kernel options on EL >= 9.3

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -31,8 +31,21 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
 
   confine exists: mkconfig_path, for_binary: true
 
+  # Add BLS specific option to mkconfig command if needed
+  #
+  # @return (String) The commandline
+  def self.mkconfig_cmdline
+    cmdline = [self.mkconfig_path]
+    if ((Facter.value(:os) && Facter.value(:os)['family']) == 'RedHat')
+      if ((Facter.value(:os)['release']['major'].to_i == 9) && (Facter.value(:os)['release']['minor'].to_i >= 3)) || (Facter.value(:os)['release']['major'].to_i > 9)
+        cmdline = cmdline.append("--update-bls-cmdline")
+      end
+    end
+    cmdline
+  end
+
   def mkconfig
-    execute(self.class.mkconfig_path, { failonfail: true, combine: false })
+    execute(self.class.mkconfig_cmdline, { failonfail: true, combine: false })
   end
 
   # when both grub* providers match, prefer GRUB 2


### PR DESCRIPTION
#### Pull Request (PR) description
This adds a required parameter `--update-bls-cmdline` to `grub2-mkconfig` on EL 9.3 and higher.

All credit goes to @loicbr for the suggestion in https://github.com/voxpupuli/puppet-augeasproviders_grub/issues/95#issuecomment-2056423827.

Note that this fixes beaker tests on EL 9 that are failing without the change.  This can be confirmed with
```
BEAKER_SETFILE=rocky9-64 BEAKER_HYPERVISOR=vagrant bundle exec rake beaker
```

#### This Pull Request (PR) fixes the following issues
Fixes #95
