### PR TITLE
fix: update-bls-cmdline is not supported on Amazon Linux 2023

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -40,6 +40,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
       return false unless os.is_a?(Hash)
 
       return false unless os['family'] == 'RedHat'
+      return false if os['name'] == 'Amazon'
       return false if os['release']['major'].to_i < 9
       return false if os['release']['major'].to_i == 9 && os['release']['minor'].to_i < 3
 

--- a/metadata.json
+++ b/metadata.json
@@ -68,6 +68,13 @@
         "8",
         "9"
       ]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "2",
+        "2023"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes incompatibility with Amazon Linux 2023, which doesn't support grub2 update-bls-cmdline
