### PR TITLE
fix: limit scope of update-bls-cmdline to RHEL9

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -35,19 +35,15 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
   #
   # @return (String) The commandline
   def self.mkconfig_cmdline
-    needs_bls_cmdline = lambda do
-      os = Facter.value(:os)
-      return false unless os.is_a?(Hash)
-
-      return false unless os['family'] == 'RedHat'
-      return false if os['release']['major'].to_i < 9
-      return false if os['release']['major'].to_i == 9 && os['release']['minor'].to_i < 3
-
-      true
-    end
+    os = Facter.value(:os)
+    # BLS cmdline option is only needed on RHEL 9.3+
+    # Fedora and Amazon Linux lack support and are excluded
+    # since they don't have a release with major version 9
+    needs_bls_cmdline = os.is_a?(Hash) && os['family'] == 'RedHat' &&
+                        os['release']['major'].to_i == 9 && os['release']['minor'].to_i >= 3
 
     cmdline = [mkconfig_path]
-    cmdline << '--update-bls-cmdline' if needs_bls_cmdline.call
+    cmdline << '--update-bls-cmdline' if needs_bls_cmdline
     cmdline
   end
 


### PR DESCRIPTION
grub2 on Amazon/Fedora is not compatible
